### PR TITLE
FOUC (Flash of Unstyled Content) fix

### DIFF
--- a/SSLTrack/Components/App.razor
+++ b/SSLTrack/Components/App.razor
@@ -2,14 +2,22 @@
 <html lang="en">
 
 <head>
+    <script>
+        (function () {
+            const match = document.cookie.match(/(^| )IsDarkMode=([^;]+)/);
+            const isDarkMode = match ? match[2] === 'true' : false;
+        })();
+        window.setDarkModeCookie = function (isDarkMode) {
+            const expires = new Date();
+            expires.setFullYear(expires.getFullYear() + 1);
+            document.cookie = `IsDarkMode=${isDarkMode}; expires=${expires.toUTCString()}; path=/; SameSite=Lax`;
+        };
+    </script>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <base href="/" />
-	
     <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" rel="stylesheet" />
     <link href="_content/MudBlazor/MudBlazor.min.css" rel="stylesheet" />
-	
-	
     <link rel="icon" type="image/png" href="favicon.ico" />
     <HeadOutlet @rendermode="@InteractiveServer" />
 </head>
@@ -17,7 +25,7 @@
 <body>
     <Routes @rendermode="@InteractiveServer" />
     <script src="_framework/blazor.web.js"></script>
-	<script src="_content/MudBlazor/MudBlazor.min.js"></script>
+    <script src="_content/MudBlazor/MudBlazor.min.js"></script>
 </body>
 
 </html>

--- a/SSLTrack/Components/Layout/MainLayout.razor
+++ b/SSLTrack/Components/Layout/MainLayout.razor
@@ -1,7 +1,8 @@
 ﻿@inherits LayoutComponentBase
-@inject Blazored.LocalStorage.ILocalStorageService localStorage
+@inject ThemeService ThemeService
+@inject IJSRuntime JSRuntime
 
-<MudThemingProvider @bind-IsDarkMode="@_isDarkMode" Theme="_theme" @rendermode="InteractiveServer" />
+<MudThemingProvider @bind-IsDarkMode="@_isDarkMode" Theme="_theme" />
 <MudPopoverProvider />
 <MudDialogProvider />
 <MudSnackbarProvider />
@@ -9,7 +10,7 @@
 
 <MudLayout>
     <MudAppBar Elevation="1">
-        <MudIconButton Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit" Edge="Edge.Start" OnClick="@((e) => DrawerToggle())" />
+        <MudIconButton Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit" Edge="Edge.Start" OnClick="@DrawerToggle" />
         <MudIcon Icon="@Icons.Material.Outlined.Lock" />
         <MudText Typo="Typo.h5" Class="ml-3">SSLTrack</MudText>
         <MudSpacer />
@@ -28,23 +29,23 @@
     private MudTheme _theme = new();
     private bool _isDarkMode;
 
-    protected override async Task OnAfterRenderAsync(bool firstRender)
+    protected override void OnInitialized()
     {
-        if (firstRender)
-        {
-            if (string.IsNullOrEmpty(await localStorage.GetItemAsync<string>("isDarkMode")))
-            {
-                await localStorage.SetItemAsync("isDarkMode", _isDarkMode);
-            }
-            _isDarkMode = bool.Parse(await localStorage.GetItemAsync<string>("isDarkMode"));
-            StateHasChanged();
-        }
+        var httpContext = new HttpContextAccessor().HttpContext;
+        _isDarkMode = ThemeService.IsDarkMode(httpContext);
     }
 
     private async Task OnThemeChanged(bool value)
     {
         _isDarkMode = value;
-        await localStorage.SetItemAsync("isDarkMode", value);
+        try
+        {
+            await JSRuntime.InvokeVoidAsync("setDarkModeCookie", value);
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Error in JS interop: {ex.Message}");
+        }
     }
 
     private void DrawerToggle()

--- a/SSLTrack/GlobalUsings.cs
+++ b/SSLTrack/GlobalUsings.cs
@@ -1,5 +1,4 @@
-﻿global using Blazored.LocalStorage;
-global using Hangfire;
+﻿global using Hangfire;
 global using MailKit.Net.Smtp;
 global using MailKit.Security;
 global using Microsoft.AspNetCore.DataProtection;

--- a/SSLTrack/Program.cs
+++ b/SSLTrack/Program.cs
@@ -21,7 +21,10 @@ builder.Services.AddTransient(provider => new SmtpClient());
 
 builder.Services.AddScoped<MailService>();
 builder.Services.AddSingleton<CertificateService>();
-builder.Services.AddBlazoredLocalStorage();
+
+builder.Services.AddHttpContextAccessor();
+builder.Services.AddScoped<ThemeService>();
+
 var app = builder.Build();
 
 if (!app.Environment.IsDevelopment())
@@ -29,6 +32,7 @@ if (!app.Environment.IsDevelopment())
     app.UseExceptionHandler("/Error", createScopeForErrors: true);
 }
 
+app.UseMiddleware<ThemeMiddleware>();
 app.MapControllers();
 app.UseStaticFiles();
 app.UseAntiforgery();

--- a/SSLTrack/SSLTrack.csproj
+++ b/SSLTrack/SSLTrack.csproj
@@ -12,7 +12,6 @@
 
   
   <ItemGroup>
-    <PackageReference Include="Blazored.LocalStorage" Version="4.5.0" />
     <PackageReference Include="Hangfire" Version="1.8.14" />
     <PackageReference Include="Hangfire.InMemory" Version="0.10.3" />
     <PackageReference Include="MailKit" Version="4.7.1.1" />

--- a/SSLTrack/Services/ThemeMiddleware.cs
+++ b/SSLTrack/Services/ThemeMiddleware.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.AspNetCore.Http;
+using System.Threading.Tasks;
+
+public class ThemeMiddleware
+{
+    private readonly RequestDelegate _next;
+
+    public ThemeMiddleware(RequestDelegate next)
+    {
+        _next = next;
+    }
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        if (context.Request.Cookies.TryGetValue("IsDarkMode", out var value))
+        {
+            context.Items["IsDarkMode"] = bool.TryParse(value, out var isDarkMode) && isDarkMode;
+        }
+        else
+        {
+            context.Items["IsDarkMode"] = false;
+        }
+
+        await _next(context);
+    }
+}

--- a/SSLTrack/Services/ThemeService.cs
+++ b/SSLTrack/Services/ThemeService.cs
@@ -1,0 +1,14 @@
+﻿using Microsoft.AspNetCore.Http;
+
+public class ThemeService
+{
+    public bool IsDarkMode(HttpContext httpContext)
+    {
+        if (httpContext?.Items.TryGetValue("IsDarkMode", out var isDarkMode) == true)
+        {
+            return (bool)isDarkMode;
+        }
+
+        return false; // default to light mode
+    }
+}


### PR DESCRIPTION
Fix [FOUC](https://en.wikipedia.org/wiki/Flash_of_unstyled_content) (white flash when refreshing page in Dark mode). Uses cookie instead of LocalStorage to allow dark/light theme render decision to be made prior to page load.

Inspiration from: https://github.com/MudBlazor/MudBlazor/discussions/9540#discussioncomment-10498541

See https://github.com/zimbres/SSLTrack/issues/4
